### PR TITLE
Fix `parse_url()` returning `false`

### DIFF
--- a/lib/Dashboard/YamlWidget.php
+++ b/lib/Dashboard/YamlWidget.php
@@ -56,8 +56,10 @@ class YamlWidget implements IAPIWidget
 		$baseURL = $this->config->getAppValue(Application::APP_ID, 'base_url', '');
 		$policy = new EmptyContentSecurityPolicy();
 		$url = parse_url($baseURL);
-		$policy->addAllowedConnectDomain('ws://' . $url['host'] . (isset($url['port']) ? ":$url[port]" : ''));
-		$policy->addAllowedConnectDomain('wss://' . $url['host'] . (isset($url['port']) ? ":$url[port]" : ''));
+		if ($url) {
+			$policy->addAllowedConnectDomain('ws://' . $url['host'] . (isset($url['port']) ? ":$url[port]" : ''));
+			$policy->addAllowedConnectDomain('wss://' . $url['host'] . (isset($url['port']) ? ":$url[port]" : ''));
+		}
 		$manager = \OC::$server->getContentSecurityPolicyManager();
 		$manager->addDefaultPolicy($policy);
 


### PR DESCRIPTION
When the BaseURL is malformed, `parse_url()` will return `false`. This change will check to make sure the URL was parsed correctly before grabbing its `host` value.